### PR TITLE
[patch] Purplship server 2021.0 

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -25,7 +25,7 @@ COPY requirements.txt /temp/
 COPY gunicorn-cfg.py .docker/docker-entrypoint.sh licenses/APACHE-LICENSE-2.0 /app/
 
 RUN pip install --upgrade pip \
-    pip install -f https://git.io/purplship -r /temp/requirements.txt \
+    pip install -r /temp/requirements.txt \
     pip freeze
 
 RUN chmod +x docker-entrypoint.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ psycopg2-binary==2.8.6
 purplship==2021.0
 purplship-server==2021.0
 purplship-server.client==2021.0
-purplship-server.core==2021.0.1
+purplship-server.core==2021.0.2
 purplship-server.manager==2021.0
 purplship-server.pricing==2021.0
 purplship-server.proxy==2021.0

--- a/src/apps/core/purpleserver/core/gateway.py
+++ b/src/apps/core/purpleserver/core/gateway.py
@@ -12,8 +12,8 @@ from purplship.core.utils import exec_async, DP
 from purpleserver.providers import models
 from purpleserver.core.exceptions import PurplShipApiException
 from purpleserver.core.datatypes import (
-    CarrierSettings, ShipmentRequest, RateRequest, Shipment,
-    RateResponse, TrackingResponse, TrackingRequest, Message, Rate, ErrorResponse,
+    ShipmentRequest, RateRequest, Shipment,
+    RateResponse, TrackingResponse, TrackingRequest, Rate, ErrorResponse,
     PickupRequest, Pickup, PickupUpdateRequest, PickupResponse, AddressValidation,
     ConfirmationResponse, PickupCancelRequest, ShipmentCancelRequest,
     AddressValidationRequest, Tracking,
@@ -34,9 +34,8 @@ class Carriers:
         list_filter: Dict[str: Any] = kwargs
         query = {}
 
-        if 'test' in list_filter:
-            test = False if list_filter['test'] is False else True
-            query.update(dict(test=test))
+        if list_filter.get('test') is not None:
+            query.update(dict(test=list_filter['test']))
 
         if 'active' in list_filter:
             active = False if list_filter['active'] is False else True

--- a/src/apps/core/setup.py
+++ b/src/apps/core/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
       name='purplship-server.core',
-      version='2021.0.1',
+      version='2021.0.2',
       description='Multi-carrier shipping API Core module',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
- fix /v1/carriers behaviour to return all carriers by default when the test flag is not passed